### PR TITLE
Transparent background on frametitle

### DIFF
--- a/beamercolorthemeusyd.sty
+++ b/beamercolorthemeusyd.sty
@@ -26,7 +26,7 @@
 \setbeamercolor*{subtitle}{parent=title, fg=usydblack}
 \setbeamercolor*{author}{parent=title, fg=usydblack}
 \setbeamercolor*{date}{parent=title, fg=usydblack}
-\setbeamercolor*{frametitle}{fg=usydred,  bg=usydwhite}
+\setbeamercolor*{frametitle}{fg=usydred,  bg=}
 
 \setbeamercolor*{block title}{fg=usydwhite, bg=usydred}
 \setbeamercolor*{block body}{fg=usydblack, bg=usydred!20}


### PR DESCRIPTION
There might be other elements that need transparent backgrounds, but this is necessary if you want a background picture on some slide(s).