### PR TITLE
Fix #8 overfull vbox warning when compiling logobar theme

### DIFF
--- a/beamerouterthemeusyd-logobar.sty
+++ b/beamerouterthemeusyd-logobar.sty
@@ -30,11 +30,11 @@
     \end{beamercolorbox}
   \else%
     \leavevmode%
-    \begin{beamercolorbox}[center,wd=.25\paperwidth,ht=1.2em,dp=1.5em]{logo in head/foot}%
+    \begin{beamercolorbox}[center,wd=0.25\paperwidth,ht=1.2em,dp=1.5em]{logo in head/foot}%
       % Move down by the depth (dp) of the colorbox
       \vspace{-1.75em}\insertlogo%
     \end{beamercolorbox}%
-    \begin{beamercolorbox}[wd=.75\paperwidth,ht=1.2em,dp=1.5em]{section in head/foot}%
+    \begin{beamercolorbox}[wd=0.75\paperwidth,ht=1.2em,dp=1.5em]{section in head/foot}%
       \insertnavigation{0.75\linewidth} \hfill %
       \insertframenumber\hspace{\theme@hpadding}
     \end{beamercolorbox}
@@ -45,7 +45,7 @@
 {%
   \ifnum\thepage=1\relax%
     % Empty colourbox on titlepage to retain spacing on subsequent pages
-    \begin{beamercolorbox}[center,wd=\paperwidth,ht=1em,dp=0.5em]{placeholder}%
+    \begin{beamercolorbox}[wd=\paperwidth,ht=1em,dp=0.5em]{placeholder}%
     \end{beamercolorbox}%
   \else%
     \leavevmode%
@@ -55,9 +55,9 @@
     \begin{beamercolorbox}[wd=0.75\paperwidth,ht=1em,dp=0.5em]{title in head/foot}%
       \hspace{\theme@hpadding}\insertshorttitle\hfill\insertdate\hspace{\theme@hpadding}
     \end{beamercolorbox}%
-    % Leave white gap at bottom of slide the same size as at top
-    \vspace{\theme@vpadding}
   \fi
+  % Leave gap at bottom of slide the same size as at top
+  \vspace{\theme@vpadding}
 }
 
 \mode<all>

--- a/beamerouterthemeusyd-logobar.sty
+++ b/beamerouterthemeusyd-logobar.sty
@@ -12,7 +12,7 @@
 
 \defbeamertemplate*{frametitle}{usyd logo}[1][]
 {%
-  \vskip2em
+  \vskip1ex
   \begin{beamercolorbox}[wd=\textwidth, #1]{frametitle}
     \usebeamerfont{frametitle}\insertframetitle\par%
   \end{beamercolorbox}
@@ -20,9 +20,15 @@
 
 \defbeamertemplate*{headline}{usyd logo}
 {%
-  \ifnum\thepage>1%
-    % Leave a white gap at the top of the slide
-    \vspace{\theme@vpadding}
+  % Leave a gap at the top of the slide before the headline
+  \vspace{\theme@vpadding}
+  \ifnum\thepage=1\relax%
+    % For beamer to not raise an error it needs to know the height of this element for all slides.
+    % This creates an placeholder for the title-page to satisfy positioning on all subsequent
+    % slides.
+    \begin{beamercolorbox}[wd=\paperwidth, ht=1.2em,dp=1.5em]{placeholder}%
+    \end{beamercolorbox}
+  \else%
     \leavevmode%
     \begin{beamercolorbox}[center,wd=.25\paperwidth,ht=1.2em,dp=1.5em]{logo in head/foot}%
       % Move down by the depth (dp) of the colorbox


### PR DESCRIPTION
Beamer needs to have all elements defined on every slide, even if those
elements are transparent. The titlepage is an exception to this. Because
the headline was only defined for slides beyond the first, when the
extra element appeared it wasn't happy givinga overfull vbox warning.

This defines the logobar as transparent elements for the titleslide to
satiate the typesetter and get rid of the warnings. This also required
some adjustments to the slide title.