### PR TITLE
fix: Set both width and height of titlegraphic (#14)

### DIFF
--- a/beamerinnerthemeusyd.sty
+++ b/beamerinnerthemeusyd.sty
@@ -7,7 +7,8 @@
     \useasboundingbox (0,0) rectangle(\the\paperwidth, \the\paperheight);
     \fill[color=usydred] (0,0) rectangle (0.5*\the\paperwidth, \the\paperheight);
     \fill[color=\USYD@titlegraphicbackground] (0.5*\the\paperwidth,0) rectangle (\the\paperwidth, \the\paperheight);
-    \node[inner sep=0pt] (titlegraphic) at (0.75*\paperwidth, 0.5*\paperheight) {\includegraphics[width=0.5\paperwidth]{\USYD@titlegraphic}};
+    \node[inner sep=0pt] (titlegraphic) at (0.75*\paperwidth, 0.5*\paperheight)
+    {\includegraphics[width=0.5\paperwidth,height=\Gin@nat@height,keepaspectratio]{\USYD@titlegraphic}};
     \hskip-10pt
     \node[inner sep=0pt] (logo) at (2.2, 1.2) {\usebeamertemplate*{logo titlepage}};
     \node[inner sep=0pt] (logo) at (6.4, 1.4) {\usebeamertemplate*{affiliationlogo titlepage}};


### PR DESCRIPTION
Pandoc sets default values for both the width and height, the minimum of
which is adhered to. This is not the desired outcome for the
titlegraphic which should fill the entire width. This sets the width to
\Gin@nat@height which overrides any default widths and heights set in
the Gin key.