### PR TITLE
Add split header theme option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The latest examples can be downloaded from the [releases page][releases] or dire
 below.
 
 - [Main theme][example.pdf]
+- [Split theme][example-split.pdf]
 - [Logobar theme][example-logobar.pdf]
 - [Poster theme][poster.pdf]
 
@@ -92,6 +93,20 @@ subsections don't make sense.
 
 This theme variation was contributed by [Joel Nothman](https://github.com/jnothman).
 
+### Split Theme
+Another variation on the theme which includes navigation elements in a bar at
+the top of each slide. It is based on the Beamer `split` outer theme. This
+option includes both section and subsection navigation and is useful for longer
+presentations.
+
+This option is enabled by passing the `split` option when specifying the theme.
+
+    \usetheme[split]{usyd}
+
+You can see this theme in action in the [example-split.pdf][] file.
+
+This theme variation was contributed by [Vanja Zecevic](https://github.com/vanja-zecevic).
+
 Poster
 ------
 
@@ -109,4 +124,5 @@ Thanks to these people for their contributions
 [releases]: https://github.com/malramsay64/usyd-beamer-theme/releases/latest
 [example.pdf]: https://github.com/malramsay64/usyd-beamer-theme/releases/download/v0.1.1/example.pdf
 [example-logobar.pdf]: https://github.com/malramsay64/usyd-beamer-theme/releases/download/v0.1.1/example-logobar.pdf
+[example-split.pdf]: https://github.com/malramsay64/usyd-beamer-theme/releases/download/v0.1.1/example-split.pdf
 [poster.pdf]: https://github.com/malramsay64/usyd-beamer-theme/releases/download/v0.1.1/poster.pdf

--- a/beamerouterthemeusyd-split.sty
+++ b/beamerouterthemeusyd-split.sty
@@ -1,0 +1,83 @@
+\mode<presentation>
+
+\beamer@compresstrue
+
+% This is the padding between text elements and the edges of the colorboxes
+\newlength{\theme@hpadding}
+\setlength{\theme@hpadding}{1.5em}
+
+% This is the whitespace on the top and bottom of the slides.
+\newlength{\theme@vpadding}
+\setlength{\theme@vpadding}{0.3em}
+
+\setbeamercolor{section in head/foot}{parent=palette quaternary}
+\setbeamercolor{subsection in head/foot}{parent=palette primary}
+
+\usesectionheadtemplate
+  {\hfill\insertsectionhead}
+  {\hfill\color{fg!50!bg}\insertsectionhead}
+
+\defbeamertemplate*{frametitle}{usyd split}[1][]
+{
+  \vskip1ex
+  \begin{beamercolorbox}[wd=\textwidth, #1]{frametitle}
+    \usebeamerfont{frametitle}\insertframetitle\par
+  \end{beamercolorbox}
+}
+
+\defbeamertemplate*{headline}{usyd split}
+{
+  \vspace{\theme@vpadding}
+  \ifnum\thepage=1\relax
+    % For beamer to not raise an error it needs to know the height of this element for all slides.
+    % This creates an placeholder for the title-page to satisfy positioning on all subsequent
+    % slides.
+    \begin{beamercolorbox}[wd=\paperwidth, ht=1.2em,dp=1.5em]{placeholder}
+    \end{beamercolorbox}
+  \else
+    \leavevmode
+    \@tempdimb=2.4375ex
+    \ifnum\beamer@subsectionmax<\beamer@sectionmax
+      \multiply\@tempdimb by\beamer@sectionmax
+    \else
+      \multiply\@tempdimb by\beamer@subsectionmax
+    \fi
+    % Limit minimum height to allow room for logo.
+    \ifdim\@tempdimb<7.3125ex
+      \@tempdimb=7.3125ex
+    \fi
+    \ifdim\@tempdimb>0pt
+      \advance\@tempdimb by 1.825ex
+      \begin{beamercolorbox}[center,wd=0.25\paperwidth,ht=\@tempdimb]{logo in head/foot}
+        \vbox to\@tempdimb{\vfil\insertlogo\vfil}
+      \end{beamercolorbox}
+      \begin{beamercolorbox}[wd=.375\paperwidth,ht=\@tempdimb]{section in head/foot}
+        \vbox to\@tempdimb{\vfil\insertsectionnavigation{.375\paperwidth}\vfil}
+      \end{beamercolorbox}
+      \begin{beamercolorbox}[wd=.375\paperwidth,ht=\@tempdimb]{subsection in head/foot}
+        \vbox to\@tempdimb{\vfil\insertsubsectionnavigation{.375\paperwidth}\vfil}
+      \end{beamercolorbox}
+    \fi
+  \fi
+}
+
+\defbeamertemplate*{footline}{usyd split}
+{
+  \ifnum\thepage=1\relax
+    % Empty colourbox on titlepage to retain spacing on subsequent pages
+    \begin{beamercolorbox}[wd=\paperwidth,ht=1em,dp=0.5em]{placeholder}
+    \end{beamercolorbox}
+  \else
+    \leavevmode
+    \begin{beamercolorbox}[center,wd=0.4\paperwidth,ht=1em,dp=0.5em]{author in head/foot}
+      \insertshortauthor
+    \end{beamercolorbox}
+    \begin{beamercolorbox}[wd=0.6\paperwidth,ht=1em,dp=0.5em]{title in head/foot}
+      \hspace{\theme@hpadding}\insertshorttitle\hfill\insertdate\hspace{\theme@hpadding}
+    \end{beamercolorbox}
+  \fi
+  % Leave gap at bottom of slide the same size as at top
+  \vspace{\theme@vpadding}
+}
+
+\mode<all>

--- a/beamerthemeusyd.sty
+++ b/beamerthemeusyd.sty
@@ -20,9 +20,17 @@
 \def\titlegraphic#1{\gdef\USYD@titlegraphic{#1}}
 \def\titlegraphicbackground#1{\gdef\USYD@titlegraphicbackground{#1}}
 
+% Declare options for choosing the theme. This gets the option
+% from the square brackets before the name of the theme. That is,
+% \usetheme[<option>]{usyd}
+% There are currently two possible options, logobar and split,
+% which define the beamer outer theme to use.
 \newif\if@logobar
 \@logobarfalse
 \DeclareOption{logobar}{\@logobartrue}
+\newif\if@split
+\@splitfalse
+\DeclareOption{split}{\@splittrue}
 \ProcessOptions
 
 % Select inner theme

--- a/beamerthemeusyd.sty
+++ b/beamerthemeusyd.sty
@@ -25,13 +25,18 @@
 \DeclareOption{logobar}{\@logobartrue}
 \ProcessOptions
 
+% Select inner theme
 \useinnertheme{usyd}
 \if@logobar
 \useoutertheme{usyd-logobar}
+\else\if@split
+\useoutertheme{usyd-split}
 \else
 \useoutertheme{usyd}
-\fi
+\fi\fi
+
 \usecolortheme{usyd}
+
 \usefonttheme{usyd}
 
 \hypersetup{

--- a/examples/example-split.tex
+++ b/examples/example-split.tex
@@ -1,0 +1,64 @@
+\documentclass[aspectratio=169, 22pt]{beamer}
+
+\makeatletter
+\def\input@path{{../}{examples/}}
+% When theme as submodule use the below line instead
+% \def\input@path{{usyd-beamer-theme/}}
+\makeatother
+
+\usepackage{amsmath}
+
+\title{The $\tau$ vs $\pi$ argument is really long and interesting}
+\subtitle{It is mostly a notational argument}
+\date{\today}
+\author[Malcolm]{Malcolm Ramsay}
+
+\usetheme[split]{usyd}
+
+\graphicspath{{../}}
+
+\titlegraphic{USYDTitle}
+\titlegraphicbackground{usydred}
+
+\begin{document}
+
+\begin{frame}
+  \titlepage{}
+\end{frame}
+
+\section{Argument}
+\subsection{In favour of $\pi$}
+
+\begin{frame}{Why use $\tau$ when there is $\pi$}
+  \begin{block}{Theorem}
+    $\tau$ is great when \href{http://blah}{dealing} with circles
+  \end{block}
+
+  \begin{enumerate}
+    \item<1-> Fourier transforms
+      \begin{equation}
+        \hat f(\zeta) = \int_{-\infty}^{+\infty} f(x) e^{-2\pi ix\zeta} dx
+      \end{equation}
+    \item<2-> A simple pendulum
+      \begin{equation}
+        T \approx 2\pi \sqrt{\frac{L}{g}}
+      \end{equation}
+  \end{enumerate}
+\end{frame}
+
+\subsection{In favour of $\tau$}
+\begin{frame}{In favour of $\tau$}
+  \begin{enumerate}
+    \item $\tau$ is a popular topic on \url{youtube.com}
+  \end{enumerate}
+\end{frame}
+
+\section{Reasoning}
+
+\begin{frame}{An excuse to write equations}
+  \begin{enumerate}
+    \item Highlight what \LaTeX is best at
+  \end{enumerate}
+\end{frame}
+
+\end{document}


### PR DESCRIPTION
Another variation on the theme which includes navigation elements in a bar at
the top of each slide. It is based on the Beamer `split` outer theme. This
option includes both section and subsection navigation and is useful for longer
presentations.